### PR TITLE
Improve compatibility page to include history and SemVer score

### DIFF
--- a/compatibility-score.html
+++ b/compatibility-score.html
@@ -28,20 +28,31 @@
           </div>
         </div>
       </nav>
+    </div>
 
-      <div class="section hero">
-        <div class="compatibility-badge">
-          <img src="#" alt="Compatibility score badge" />
+    <div class="container">
+      <div class="section compatibility-score-container">
+
+        <h2><span class="page-title-prefix"></span><span class="repo-name"></span></h2>
+        <h3 class="subtitle-version"></h3>
+
+        <div class="compatibility-boxes">
+          <div class="compatibility-box compatibility-scores">
+          </div>
+
+          <div class="compatibility-box compatibility-blurb">
+            <p class="compatibility-blurb-placeholder"></p>
+            <p>Projects without CI, or without a previously passing test suite, are excluded from the scores. <span class="semver-score-caveat"></span></p>
+            <p>Dependabot creates pull requests for thousands of organisations to help them keep their dependencies up to date.</p>
+          </div>
         </div>
-        <h2>Rely on everyone else's test suites</h2>
-        <p>Dependabot aggregates everyone's test suite results to check a dependency update is backwards compatible.</p>
       </div>
     </div>
 
     <div class="container">
       <div class="section how-it-works">
         <a name="how-it-works"></a>
-        <h2>How it's calculated</h2>
+        <h2>How the compatibility score is calculated</h2>
         <div class="how-it-works-boxes">
           <div class="how-it-works-box">
             <div class="how-it-works-icon">
@@ -70,63 +81,7 @@
             </div>
             <div class="how-it-works-description">
               <h3>We show you the pass rate</h3>
-              <p>Our compatibility score is the % of CI runs that passed when updating from your current version to the new one.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="container">
-      <div class="section statuses">
-        <a name="statuses"></a>
-        <h2>The statuses</h2>
-        <div class="statuses-table">
-          <div class="status-row">
-            <div class="status">
-              <img src="https://api.dependabot.com/badges/ci_status?dependency-name=pg&package-manager=bundler&previous-version=0.20.0&new-version=0.21.0" alt="Compatibility score badge" /></div>
-            <div class="status-details">
-              <p>The update passed CI checks on X% of repos. Repos without CI, or without a previously passing test suite, are excluded, as are test runs that are still pending.</p>
-            </div>
-          </div>
-          <div class="status-row">
-            <div class="status">
-              <img src="https://api.dependabot.com/badges/ci_status?dependency-name=pg&package-manager=bundler&previous-version=0.20.0&new-version=unknown" alt="Compatibility score badge" />
-            </div>
-            <div class="status-details">
-              <p>The update was not made to enough repositories for Dependabot to form a view on compatibility. Help us fix that by introducing more people to Dependabot!</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="container">
-      <div class="section">
-        <a name="features"></a>
-        <h2>How it can help you</h2>
-        <div class="feature-boxes">
-          <div class="feature-box">
-            <div class="feature-icon">
-              <img src="/images/icon-code.svg" />
-            </div>
-            <div class="feature-description">
-              <h3>Check backwards compatibility</h3>
-              <p>
-                Not all dependency authors use semantic versioning. Not all dependencies are post v1.0.0. When you can't rely on SemVer, checking everyone's tests pass is the next best thing.
-              </p>
-            </div>
-          </div>
-
-          <div class="feature-box">
-            <div class="feature-icon">
-              <img src="/images/icon-tick.svg" />
-            </div>
-            <div class="feature-description">
-              <h3>Avoid buggy releases</h3>
-              <p>
-                Despite everyone's best intentions, bugs sometimes creep into new releases. When you know that everyone's tests pass, however, you can be relatively sure an update is bug-free.
-              </p>
+              <p>The compatibility score is the percentage of CI runs that passed when updating between relevant versions.</p>
             </div>
           </div>
         </div>
@@ -147,7 +102,9 @@
     </div>
   </div>
 
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.10/lodash.min.js"></script>
+
   <script>
     var nav = $(".nav");
     $(".nav-toggle").click(function () {
@@ -158,6 +115,7 @@
       nav.removeClass("menu-open");
     });
   </script>
+
   <script>
     function getUrlParameter(sParam) {
       var sPageURL = decodeURIComponent(window.location.search.substring(1)),
@@ -174,7 +132,160 @@
       }
     };
 
-    $('.compatibility-badge img').attr("src", `https://api.dependabot.com/badges/ci_status?dependency-name=${getUrlParameter('dependency-name') || 'pg'}&package-manager=${getUrlParameter('package-manager') || 'bundler'}&previous-version=${getUrlParameter('previous-version') || '0.20.0'}&new-version=${getUrlParameter('new-version') || '0.21.0'}`);
+    function fetchSemVerData(dependencyName, packageManager) {
+      return $.get({
+        url: "https://api.dependabot.com/compatibility_scores",
+        data: {
+          "dependency-name": dependencyName,
+          "package-manager": packageManager,
+        },
+      })
+    }
+
+    function semverScore(total, successful) {
+      return Math.round(100.0 * successful / total);
+    }
+
+    function compatibilityBadgeUrl(dependencyName, packageManager, previousVersion, newVersion) {
+      // If we're not supplying versions, get a badge for the entire dependency history
+      // Otherwise, get a badge for just the version bump we care about
+      if (previousVersion && newVersion) {
+        return `https://api.dependabot.com/badges/compatibility_score?dependency-name=${dependencyName}&package-manager=${packageManager}&previous-version=${previousVersion}&new-version=${newVersion}`
+      } else {
+        return `https://api.dependabot.com/badges/compatibility_score?dependency-name=${dependencyName}&package-manager=${packageManager}&version-scheme=semver`
+      }
+    }
+
+    function buildCompatibilityScoreElement(dependencyName, packageManager, previousVersion, newVersion, versionString) {
+      var newScore = $("<div class='compatibility-score'></div>");
+      var newScoreBadge = $("<div class='compatibility-score-badge'></div>");
+      var newScoreBadgeImg = $("<img/>");
+      newScoreBadgeImg.attr("src", compatibilityBadgeUrl(dependencyName, packageManager, previousVersion, newVersion));
+      newScoreBadge.append(newScoreBadgeImg);
+      newScore.append(newScoreBadge)
+
+      var newScoreFooter = $("<div class='compatibility-score-footer'></div>");
+      var newScoreVersion = $("<div class='compatibility-score-version'></div>");
+      if (versionString == null) {
+        var allUrl = `${window.location.href.split('?')[0]}?dependency-name=${dependencyName}&package-manager=${packageManager}`
+        newScoreVersion.append($(`<a href=${allUrl}>See scores for all releases of ${dependencyName}</a>`));
+      } else {
+        newScoreVersion.text(versionString);
+      }
+      newScoreFooter.append(newScoreVersion);
+      newScore.append(newScoreFooter);
+
+      return newScore;
+    }
+
+    // For now, we just support two cases, either we're doing a specific update
+    // from VX to Vy, or we're looking at a dependency irrespective of version.
+    //
+    // In either case, if we don't have enough data then just provide the 'unknown' UI.
+    //
+    // TODO: de-dupe the magic `< 5` condition (which is also defined in the backend) by
+    // exposing something to indicate this in the API?
+    function render(dependencyName, packageManager, previousVersion, newVersion, data) {
+      $(".repo-name").text(dependencyName);
+
+      if (previousVersion && newVersion) {
+        $(".page-title-prefix").text('Compatibility score for ');
+        $(".subtitle-version").text(`${previousVersion} ... ${newVersion}`);
+        $('.compatibility-scores').append(
+          buildCompatibilityScoreElement(dependencyName, packageManager, previousVersion, newVersion, null).addClass("primary")
+        )
+
+        var update = _.find(data.updates, { previous_version: previousVersion, updated_version: newVersion });
+        if (!update || update.candidate_updates < 5) {
+          $(".compatibility-blurb-placeholder").append(`Dependabot hasn't made enough updates for projects migrating <strong>${dependencyName}</strong> from <strong>${previousVersion}</strong> to <strong>${ newVersion }</strong> to form a view on compatibility yet.`)
+        } else {
+          $(".compatibility-blurb-placeholder").append(`Dependabot has performed <strong>${ update.candidate_updates }</strong> updates of <strong>${ dependencyName }</strong> from <strong>${ previousVersion }</strong> to <strong>${ newVersion }</strong> and <strong>${ semverScore(update.candidate_updates, update.successful_updates) }%</strong> of those updates passed CI.`)
+        }
+      } else {
+        $(".page-title-prefix").text('SemVer compatibility score for ');
+        $(".semver-score-caveat").text('SemVer incompatible updates are excluded from the overall SemVer score.');
+
+        if (data.total_semver_compatible_updates < 5) {
+          $(".compatibility-blurb-placeholder").append(`Dependabot hasn't made enough SemVer compatible updates for <strong>${dependencyName}</strong> to form a view on its compatibility yet.`)
+        } else {
+          $(".compatibility-blurb-placeholder").append(`Dependabot has performed <strong>${ data.total_semver_compatible_updates }</strong> updates of <strong>${ dependencyName }</strong> between SemVer compatible versions, and <strong>${ semverScore(data["total_semver_compatible_updates"], data["successful_semver_compatible_updates"]) }%</strong> of those updates passed CI.`)
+        }
+
+        $('.compatibility-scores').append(
+          buildCompatibilityScoreElement(dependencyName, packageManager, null, null, "All releases").addClass("primary")
+        )
+
+        function renderUpdates(updates) {
+          var mostRecentUpdates = _.takeRight(updates, 3);
+
+          _.each(_.reverse(mostRecentUpdates), function(update) {
+            $('.compatibility-scores').append(
+              buildCompatibilityScoreElement(
+                dependencyName,
+                packageManager,
+                update.previous_version,
+                update.updated_version,
+                update.previous_version + " → " + update.updated_version
+              )
+            )
+          })
+
+          if (updates.length > 3) {
+            var seeMoreLink = $("<span class='compatibility-scores-more-link'>... see more</span>")
+            seeMoreLink.click(function() {
+              seeMoreLink.remove();
+              renderUpdates(_.dropRight(updates, 3))
+            })
+
+            $('.compatibility-scores').append(seeMoreLink)
+          }
+        }
+
+        renderUpdates(data["updates"])
+      }
+    }
+
+    var params = {
+      dependencyName: getUrlParameter("dependency-name"),
+      packageManager: getUrlParameter("package-manager"),
+      previousVersion: getUrlParameter("previous-version"),
+      newVersion: getUrlParameter("new-version")
+    }
+
+    // If we're hitting the page with no expectations, let's show the semver
+    // compatibility for a common dependency
+    if (!params.previousVersion && !params.newVersion && !params.dependencyName && !params.packageManager) {
+      var popularDependencies = [
+        ["uglifier", "bundler"],
+        ["sinatra", "bundler"],
+        ["rubocop", "bundler"],
+        ["rails", "bundler"],
+        ["puma", "bundler"],
+        ["webpack", "npm_and_yarn"],
+        ["eslint", "npm_and_yarn"],
+        ["react", "npm_and_yarn"],
+        ["jest", "npm_and_yarn"],
+        ["django", "pip"],
+        ["pytest", "pip"],
+        ["boto3", "pip"]
+      ]
+      var dep = popularDependencies[Math.floor(Math.random() * popularDependencies.length)];
+      params.dependencyName = dep[0]
+      params.packageManager = dep[1]
+    }
+
+    fetchSemVerData(
+      params.dependencyName,
+      params.packageManager,
+    ).then(data => {
+      render(
+        params.dependencyName,
+        params.packageManager,
+        params.previousVersion,
+        params.newVersion,
+        data,
+      )
+    })
   </script>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/css/main.css
+++ b/css/main.css
@@ -1,37 +1,23 @@
-/*! normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */
+/*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
 /* Document
    ========================================================================== */
 /**
  * 1. Correct the line height in all browsers.
- * 2. Prevent adjustments of font size after orientation changes in
- *    IE on Windows Phone and in iOS.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 html {
   line-height: 1.15;
   /* 1 */
-  -ms-text-size-adjust: 100%;
-  /* 2 */
   -webkit-text-size-adjust: 100%;
   /* 2 */ }
 
 /* Sections
    ========================================================================== */
 /**
- * Remove the margin in all browsers (opinionated).
+ * Remove the margin in all browsers.
  */
 body {
   margin: 0; }
-
-/**
- * Add the correct display in IE 9-.
- */
-article,
-aside,
-footer,
-header,
-nav,
-section {
-  display: block; }
 
 /**
  * Correct the font size and margin on `h1` elements within `section` and
@@ -43,22 +29,6 @@ h1 {
 
 /* Grouping content
    ========================================================================== */
-/**
- * Add the correct display in IE 9-.
- * 1. Add the correct display in IE.
- */
-figcaption,
-figure,
-main {
-  /* 1 */
-  display: block; }
-
-/**
- * Add the correct margin in IE 8.
- */
-figure {
-  margin: 1em 40px; }
-
 /**
  * 1. Add the correct box sizing in Firefox.
  * 2. Show the overflow in Edge and IE.
@@ -84,17 +54,13 @@ pre {
 /* Text-level semantics
    ========================================================================== */
 /**
- * 1. Remove the gray background on active links in IE 10.
- * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ * Remove the gray background on active links in IE 10.
  */
 a {
-  background-color: transparent;
-  /* 1 */
-  -webkit-text-decoration-skip: objects;
-  /* 2 */ }
+  background-color: transparent; }
 
 /**
- * 1. Remove the bottom border in Chrome 57- and Firefox 39-.
+ * 1. Remove the bottom border in Chrome 57-
  * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
  */
 abbr[title] {
@@ -104,13 +70,6 @@ abbr[title] {
   /* 2 */
   text-decoration: underline dotted;
   /* 2 */ }
-
-/**
- * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
- */
-b,
-strong {
-  font-weight: inherit; }
 
 /**
  * Add the correct font weight in Chrome, Edge, and Safari.
@@ -130,19 +89,6 @@ samp {
   /* 1 */
   font-size: 1em;
   /* 2 */ }
-
-/**
- * Add the correct font style in Android 4.3-.
- */
-dfn {
-  font-style: italic; }
-
-/**
- * Add the correct background and color in IE 9-.
- */
-mark {
-  background-color: #ff0;
-  color: #000; }
 
 /**
  * Add the correct font size in all browsers.
@@ -170,35 +116,15 @@ sup {
 /* Embedded content
    ========================================================================== */
 /**
- * Add the correct display in IE 9-.
- */
-audio,
-video {
-  display: inline-block; }
-
-/**
- * Add the correct display in iOS 4-7.
- */
-audio:not([controls]) {
-  display: none;
-  height: 0; }
-
-/**
- * Remove the border on images inside links in IE 10-.
+ * Remove the border on images inside links in IE 10.
  */
 img {
   border-style: none; }
 
-/**
- * Hide the overflow in IE.
- */
-svg:not(:root) {
-  overflow: hidden; }
-
 /* Forms
    ========================================================================== */
 /**
- * 1. Change the font styles in all browsers (opinionated).
+ * 1. Change the font styles in all browsers.
  * 2. Remove the margin in Firefox and Safari.
  */
 button,
@@ -206,7 +132,7 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: sans-serif;
+  font-family: inherit;
   /* 1 */
   font-size: 100%;
   /* 1 */
@@ -234,16 +160,13 @@ select {
   text-transform: none; }
 
 /**
- * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
- *    controls in Android 4.
- * 2. Correct the inability to style clickable types in iOS and Safari.
+ * Correct the inability to style clickable types in iOS and Safari.
  */
 button,
-html [type="button"],
+[type="button"],
 [type="reset"],
 [type="submit"] {
-  -webkit-appearance: button;
-  /* 2 */ }
+  -webkit-appearance: button; }
 
 /**
  * Remove the inner border and padding in Firefox.
@@ -291,24 +214,20 @@ legend {
   /* 1 */ }
 
 /**
- * 1. Add the correct display in IE 9-.
- * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
  */
 progress {
-  display: inline-block;
-  /* 1 */
-  vertical-align: baseline;
-  /* 2 */ }
+  vertical-align: baseline; }
 
 /**
- * Remove the default vertical scrollbar in IE.
+ * Remove the default vertical scrollbar in IE 10+.
  */
 textarea {
   overflow: auto; }
 
 /**
- * 1. Add the correct box sizing in IE 10-.
- * 2. Remove the padding in IE 10-.
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
  */
 [type="checkbox"],
 [type="radio"] {
@@ -335,9 +254,8 @@ textarea {
   /* 2 */ }
 
 /**
- * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+ * Remove the inner padding in Chrome and Safari on macOS.
  */
-[type="search"]::-webkit-search-cancel-button,
 [type="search"]::-webkit-search-decoration {
   -webkit-appearance: none; }
 
@@ -354,11 +272,9 @@ textarea {
 /* Interactive
    ========================================================================== */
 /*
- * Add the correct display in IE 9-.
- * 1. Add the correct display in Edge, IE, and Firefox.
+ * Add the correct display in Edge, IE 10+, and Firefox.
  */
-details,
-menu {
+details {
   display: block; }
 
 /*
@@ -367,24 +283,16 @@ menu {
 summary {
   display: list-item; }
 
-/* Scripting
+/* Misc
    ========================================================================== */
 /**
- * Add the correct display in IE 9-.
- */
-canvas {
-  display: inline-block; }
-
-/**
- * Add the correct display in IE.
+ * Add the correct display in IE 10+.
  */
 template {
   display: none; }
 
-/* Hidden
-   ========================================================================== */
 /**
- * Add the correct display in IE 10-.
+ * Add the correct display in IE 10.
  */
 [hidden] {
   display: none; }
@@ -682,6 +590,79 @@ hr {
 .compatibility-badge img {
   width: 400px;
   max-width: 90%; }
+
+.compatibility-score-container .repo-name {
+  text-decoration: underline;
+  font-style: italic;
+  font-weight: 800; }
+
+.compatibility-score-container h2 {
+  margin-bottom: 0.5rem; }
+
+.compatibility-score-container h3 {
+  margin-top: 0.7rem;
+  margin-bottom: 3rem;
+  color: #9E9E9E;
+  font-weight: 600; }
+
+.compatibility-boxes {
+  display: flex;
+  flex-direction: row; }
+
+.compatibility-box {
+  flex: 1;
+  display: flex;
+  flex-direction: column; }
+
+.compatibility-blurb {
+  text-align: left; }
+
+.compatibility-blurb strong {
+  font-weight: 700; }
+
+.compatibility-blurb p:first-of-type {
+  margin-top: 0; }
+
+.compatibility-scores {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding-right: 30px; }
+  @media only screen and (min-width: 768px) {
+    .compatibility-scores {
+      padding-right: 100px; } }
+
+.compatibility-score {
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px; }
+
+.compatibility-score:first-of-type {
+  margin-top: 0; }
+
+.compatibility-score-badge {
+  align-self: flex-end; }
+
+.compatibility-score.primary .compatibility-score-badge {
+  align-self: stretch; }
+
+.compatibility-score .compatibility-score-badge img {
+  width: 100%; }
+
+.compatibility-score-footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  line-height: 0.9em;
+  font-size: 0.8em;
+  font-weight: 400; }
+
+.compatibility-scores-more-link {
+  text-align: right;
+  cursor: pointer;
+  color: #0025ff;
+  margin-top: 0.6rem;
+  font-size: 0.8rem; }
 
 .language-hero img {
   height: 100px;

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -144,6 +144,98 @@
   max-width: 90%;
 }
 
+.compatibility-score-container .repo-name {
+  text-decoration: underline;
+  font-style: italic;
+  font-weight: 800;
+}
+
+.compatibility-score-container {
+}
+
+.compatibility-score-container h2 {
+  margin-bottom: 0.5rem;
+}
+
+.compatibility-score-container h3 {
+  margin-top: 0.7rem;
+  margin-bottom: 3rem;
+  color: #9E9E9E;
+  font-weight: 600;
+}
+
+.compatibility-boxes {
+  display: flex;
+  flex-direction: row;
+}
+
+.compatibility-box {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.compatibility-blurb {
+  text-align: left;
+}
+
+.compatibility-blurb strong {
+  font-weight: 700;
+}
+
+.compatibility-blurb p:first-of-type {
+  margin-top: 0;
+}
+
+.compatibility-scores {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding-right: 30px;
+  @media only screen and (min-width: 768px) {
+    padding-right: 100px;
+  }
+}
+
+.compatibility-score {
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+}
+
+.compatibility-score:first-of-type {
+  margin-top: 0;
+}
+
+.compatibility-score-badge {
+  align-self: flex-end;
+}
+
+.compatibility-score.primary .compatibility-score-badge {
+  align-self: stretch;
+}
+
+.compatibility-score .compatibility-score-badge img {
+  width: 100%;
+}
+
+.compatibility-score-footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  line-height: 0.9em;
+  font-size: 0.8em;
+  font-weight: 400;
+}
+
+.compatibility-scores-more-link {
+  text-align: right;
+  cursor: pointer;
+  color: #0025ff;
+  margin-top: 0.6rem;
+  font-size: 0.8rem;
+}
+
 .language-hero img {
   height: 100px;
   max-width: 45%;


### PR DESCRIPTION
After this, users can add a badge to their site displaying their SemVer
score, which links to a page explaining what it means.

The compatibility scores that Dependabot already shows in PRs also now
link to an updated screen, following the same design.

---

*New default compatibility page/dependency without version*
![image](https://user-images.githubusercontent.com/510845/41426638-2b0747a8-6ffc-11e8-8136-a66d4a6ab521.png)

*New dependency semver page and badge*
![image](https://user-images.githubusercontent.com/510845/41426725-6e18b608-6ffc-11e8-8647-8f1d9e4d01ac.png)

*New dependency compatibility (specific version bump, linked from dependabot PR)*
![image](https://user-images.githubusercontent.com/510845/41426734-7404fb58-6ffc-11e8-8c2a-14bcf35d894a.png)

*New dependency compatibility (not enough data)*
![image](https://user-images.githubusercontent.com/510845/41426721-6856e730-6ffc-11e8-921c-a802ec3c6538.png)

*New dependency semver (not enough data)*
![image](https://user-images.githubusercontent.com/510845/41426743-781ecf7a-6ffc-11e8-9eb2-37509623187e.png)

