### PR TITLE
Add signup links on non-main pages

### DIFF
--- a/compatibility-score.html
+++ b/compatibility-score.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/docker.html
+++ b/docker.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/elixir.html
+++ b/elixir.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/java.html
+++ b/java.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/javascript.html
+++ b/javascript.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/php.html
+++ b/php.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/python.html
+++ b/python.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/ruby.html
+++ b/ruby.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/rust.html
+++ b/rust.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>

--- a/submodules.html
+++ b/submodules.html
@@ -25,6 +25,10 @@
             <a class="button compact" href="//app.dependabot.com/auth/sign-in?immediate=true">
               <span>Log in</span>
             </a>
+            &nbsp;
+            <a class="button compact primary" href="//app.dependabot.com/auth/sign-up">
+              <span>Sign up</span>
+            </a>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
Currently, the only page with a signup button is the homepage. All other pages only have a login button.

This commit adds signup buttons to the compatibility score and language pages.e.g.,

![image](https://user-images.githubusercontent.com/510845/41507183-6a0f51d6-7225-11e8-9dde-c56f7204f3c0.png)

