### PR TITLE
Make compatibility badges clickable

### DIFF
--- a/compatibility-score.html
+++ b/compatibility-score.html
@@ -156,9 +156,23 @@
       }
     }
 
-    function buildCompatibilityScoreElement(dependencyName, packageManager, previousVersion, newVersion, versionString) {
+    function compatibilityScoreUrl(dependencyName, packageManager, previousVersion, newVersion) {
+      return `${window.location.href.split('?')[0]}?dependency-name=${dependencyName}&package-manager=${packageManager}&previous-version=${previousVersion}&new-version=${newVersion}`
+    }
+
+    function buildCompatibilityScoreElement(dependencyName, packageManager, previousVersion, newVersion, versionString, enableLink = false) {
       var newScore = $("<div class='compatibility-score'></div>");
-      var newScoreBadge = $("<div class='compatibility-score-badge'></div>");
+
+      var newScoreBadge;
+      if (enableLink) {
+        newScoreBadge = $("<a class='compatibility-score-badge'></a>").attr(
+          "href",
+          compatibilityScoreUrl(dependencyName, packageManager, previousVersion, newVersion)
+        )
+      } else {
+        newScoreBadge = $("<div class='compatibility-score-badge'></div>");
+      }
+
       var newScoreBadgeImg = $("<img/>");
       newScoreBadgeImg.attr("src", compatibilityBadgeUrl(dependencyName, packageManager, previousVersion, newVersion));
       newScoreBadge.append(newScoreBadgeImg);
@@ -225,7 +239,8 @@
                 packageManager,
                 update.previous_version,
                 update.updated_version,
-                update.previous_version + " → " + update.updated_version
+                update.previous_version + " → " + update.updated_version,
+                true
               )
             )
           })


### PR DESCRIPTION
Means that users can more easily explore compatibility on specific
version bumps listed on the main dependency compatibility page.